### PR TITLE
Define shared API schemas

### DIFF
--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,28 @@
+from app.schemas.jobs import JobStatus, SourceType, JobCreateResponse, JobStatusResponse
+from app.schemas.reports import GeminiReport
+from app.schemas.visualization import BrainFrame, BrainVisualizationPayload, ProgressEvent
+from app.schemas.analysis import (
+    YouTubeAnalyzeRequest,
+    VideoMetadata,
+    DangerSegment,
+    AnalysisSummary,
+    RoiTimeSeries,
+    AnalysisResult,
+)
+
+__all__ = [
+    "JobStatus",
+    "SourceType",
+    "JobCreateResponse",
+    "JobStatusResponse",
+    "GeminiReport",
+    "BrainFrame",
+    "BrainVisualizationPayload",
+    "ProgressEvent",
+    "YouTubeAnalyzeRequest",
+    "VideoMetadata",
+    "DangerSegment",
+    "AnalysisSummary",
+    "RoiTimeSeries",
+    "AnalysisResult",
+]

--- a/backend/app/schemas/analysis.py
+++ b/backend/app/schemas/analysis.py
@@ -1,0 +1,57 @@
+from typing import List, Optional
+from pydantic import BaseModel, Field, ConfigDict, field_validator
+from app.schemas.jobs import JobStatus
+from app.schemas.reports import GeminiReport
+from app.schemas.visualization import BrainVisualizationPayload
+
+class YouTubeAnalyzeRequest(BaseModel):
+    url: str
+
+    @field_validator("url")
+    @classmethod
+    def url_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("URL cannot be empty")
+        return v
+
+class VideoMetadata(BaseModel):
+    filename: str
+    duration_seconds: float
+    fps: float
+    resolution: str
+
+class DangerSegment(BaseModel):
+    start_time: float
+    end_time: float
+    peak_time: float
+    roi: str
+    activation_level: float
+    threshold: float
+    severity: str
+    reason: str
+
+class AnalysisSummary(BaseModel):
+    severity: str
+    segments_detected: int
+    total_danger_duration_seconds: float
+
+class RoiTimeSeries(BaseModel):
+    timestamps: List[float]
+    V1: List[float]
+    V2: List[float]
+    V3: List[float]
+    V4: List[float]
+    MT_plus: List[float] = Field(..., serialization_alias="MT+")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+class AnalysisResult(BaseModel):
+    job_id: str
+    status: JobStatus
+    video: VideoMetadata
+    danger_score: int
+    summary: AnalysisSummary
+    danger_segments: List[DangerSegment]
+    roi_timeseries: RoiTimeSeries
+    gemini_report: GeminiReport
+    brain_visualization: Optional[BrainVisualizationPayload] = None

--- a/backend/app/schemas/jobs.py
+++ b/backend/app/schemas/jobs.py
@@ -1,0 +1,37 @@
+from enum import Enum
+from typing import Optional, TYPE_CHECKING
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from app.schemas.analysis import AnalysisResult
+
+class JobStatus(str, Enum):
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    EXTRACTING_METADATA = "extracting_metadata"
+    RUNNING_MODEL = "running_model"
+    SCORING_DANGER = "scoring_danger"
+    GENERATING_VISUALIZATION = "generating_visualization"
+    GENERATING_REPORT = "generating_report"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+class SourceType(str, Enum):
+    UPLOAD = "upload"
+    YOUTUBE = "youtube"
+    DEMO = "demo"
+
+class JobCreateResponse(BaseModel):
+    job_id: str
+    status: JobStatus
+    message: str
+
+class JobStatusResponse(BaseModel):
+    job_id: str
+    status: JobStatus
+    progress: int
+    message: str
+    result: Optional["AnalysisResult"] = None
+    error: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/reports.py
+++ b/backend/app/schemas/reports.py
@@ -1,0 +1,7 @@
+from typing import List
+from pydantic import BaseModel
+
+class GeminiReport(BaseModel):
+    headline: str
+    findings: List[str]
+    recommended_actions: List[str]

--- a/backend/app/schemas/visualization.py
+++ b/backend/app/schemas/visualization.py
@@ -1,0 +1,23 @@
+from typing import List, Dict, Optional
+from pydantic import BaseModel, Field
+from app.schemas.jobs import JobStatus
+
+class BrainFrame(BaseModel):
+    timestamp: float
+    roi_activations: Dict[str, float]
+    max_activation: float
+    danger_level: str
+
+class BrainVisualizationPayload(BaseModel):
+    job_id: str
+    frames: List[BrainFrame]
+    color_map: str = "deep-blue-yellow-red"
+    timestamp_unit: str = "seconds"
+
+class ProgressEvent(BaseModel):
+    job_id: str
+    status: JobStatus
+    progress: int
+    message: str
+    timestamp: Optional[str] = None
+    brain_frame: Optional[BrainFrame] = None


### PR DESCRIPTION
## Summary

Defines the shared Pydantic API schemas for the NeuroSafe backend contract between the backend integration layer, future model adapter, frontend, and brain visualization pipeline.

## Changes

- Added job-related schemas and enums:
  - `JobStatus`
  - `SourceType`
  - `JobCreateResponse`
  - `JobStatusResponse`

- Added analysis schemas:
  - `YouTubeAnalyzeRequest`
  - `VideoMetadata`
  - `DangerSegment`
  - `AnalysisSummary`
  - `RoiTimeSeries`
  - `AnalysisResult`

- Added report schema:
  - `GeminiReport`

- Added brain visualization / WebSocket schemas:
  - `BrainFrame`
  - `BrainVisualizationPayload`
  - `ProgressEvent`

- Added centralized schema exports in `backend/app/schemas/__init__.py`.

## Validation

Tested locally from `backend/`:

```bash
python -c "from app.schemas.analysis import RoiTimeSeries; r=RoiTimeSeries(timestamps=[0], V1=[0.1], V2=[0.2], V3=[0.3], V4=[0.4], MT_plus=[0.5]); print(r.model_dump(by_alias=True))"

Closes #2 