### PR TITLE
Add video upload analysis endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -58,6 +58,11 @@ uvicorn app.main:app --reload
   ```bash
   python -c "import asyncio; from app.services.job_store import job_store; from app.schemas.jobs import SourceType; from app.services.orchestrator import analysis_orchestrator; j=job_store.create_job(SourceType.DEMO, 'demo-video.mp4'); result=asyncio.run(analysis_orchestrator.run_demo_analysis(j.job_id)); print(result.job_id, result.status, result.danger_score); print(job_store.get_job(j.job_id).status, job_store.get_job(j.job_id).progress); print(result.brain_visualization.frames[0].timestamp, result.roi_timeseries.timestamps[0])"
   ```
+- **Upload Test (Windows):**
+  ```powershell
+  echo "fake video content" > test.mp4
+  curl.exe -X POST http://localhost:8000/api/analyze/upload -F "file=@test.mp4"
+  ```
 
 ## Note
 This is an initial scaffold. Model integration, job orchestration, Gemini integration, yt-dlp, and danger scoring will be added in later branches.

--- a/backend/app/api/routes/analysis.py
+++ b/backend/app/api/routes/analysis.py
@@ -1,12 +1,61 @@
-from fastapi import APIRouter
+import shutil
+import os
+from pathlib import Path
+from fastapi import APIRouter, UploadFile, File, BackgroundTasks, HTTPException
+from app.schemas.jobs import JobCreateResponse, SourceType
+from app.services.job_store import job_store
+from app.services.orchestrator import analysis_orchestrator
+from app.core.config import settings
 
 router = APIRouter()
 
-@router.post("/upload")
-async def analyze_upload():
-    return {
-        "message": "Analysis endpoint scaffolded. Job orchestration will be implemented in a later branch."
-    }
+ALLOWED_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm"}
+
+@router.post("/upload", response_model=JobCreateResponse)
+async def analyze_upload(
+    background_tasks: BackgroundTasks,
+    file: UploadFile = File(...)
+):
+    # 1. Basic Validation
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="Filename is empty")
+    
+    file_ext = Path(file.filename).suffix.lower()
+    if file_ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400, 
+            detail=f"Unsupported file extension. Allowed: {', '.join(ALLOWED_EXTENSIONS)}"
+        )
+
+    # 2. Create Job
+    job = job_store.create_job(
+        source_type=SourceType.UPLOAD,
+        source_name=file.filename,
+        message="Video accepted. Analysis starting..."
+    )
+
+    # 3. Save File
+    try:
+        upload_dir = Path(settings.UPLOAD_DIR)
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        
+        file_path = upload_dir / f"{job.job_id}_{file.filename}"
+        
+        with file_path.open("wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+            
+    except Exception as e:
+        job_store.fail_job(job.job_id, error=str(e), message="Failed to save uploaded file")
+        raise HTTPException(status_code=500, detail=f"Could not save file: {e}")
+
+    # 4. Start Background Analysis
+    background_tasks.add_task(analysis_orchestrator.run_demo_analysis, job.job_id)
+
+    return JobCreateResponse(
+        job_id=job.job_id,
+        status=job.status,
+        message="Video accepted. Analysis started."
+    )
 
 @router.post("/youtube")
 async def analyze_youtube():


### PR DESCRIPTION
## Summary

Implements the video upload analysis endpoint for NeuroSafe. The frontend can now submit a video file, receive a job ID immediately, and have demo analysis started in the background.

Closes #5 

## Changes

- Updated `backend/app/api/routes/analysis.py`
  - Implemented `POST /api/analyze/upload`
  - Accepts multipart form-data using FastAPI `UploadFile`
  - Validates common video extensions
  - Saves uploaded files to the configured `UPLOAD_DIR`
  - Creates an analysis job in the in-memory job store
  - Starts demo analysis using FastAPI `BackgroundTasks`
  - Returns a `JobCreateResponse`

- Updated `backend/README.md`
  - Added upload endpoint verification instructions

## Upload Behavior

The endpoint accepts a form field named `file`.

Allowed extensions:

- `.mp4`
- `.mov`
- `.avi`
- `.mkv`
- `.webm`

Uploaded files are saved with a job-prefixed filename to avoid collisions, for example:

```text
uploads/job_abcd1234_test.mp4