### PR TITLE
Add analysis results endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -71,6 +71,14 @@ uvicorn app.main:app --reload
   ```powershell
   curl.exe -X POST http://localhost:8000/api/analyze/youtube -H "Content-Type: application/json" -d "{\"url\":\"https://example.com/video\"}"
   ```
+- **Polling Status & Results:**
+  1. Submit a job (Upload or YouTube).
+  2. Copy the `job_id` from the response.
+  3. Poll the status:
+     ```powershell
+     curl.exe http://localhost:8000/api/analyze/{job_id}
+     ```
+  4. After ~1-2 seconds, the `status` will be `completed` and the `result` field will be populated.
 
 ## Note
 This is an initial scaffold. Model integration, job orchestration, Gemini integration, yt-dlp, and danger scoring will be added in later branches.

--- a/backend/app/api/routes/analysis.py
+++ b/backend/app/api/routes/analysis.py
@@ -2,7 +2,7 @@ import shutil
 import os
 from pathlib import Path
 from fastapi import APIRouter, UploadFile, File, BackgroundTasks, HTTPException
-from app.schemas.jobs import JobCreateResponse, SourceType
+from app.schemas.jobs import JobCreateResponse, SourceType, JobStatusResponse
 from app.schemas.analysis import YouTubeAnalyzeRequest
 from app.services.job_store import job_store
 from app.services.orchestrator import analysis_orchestrator
@@ -90,9 +90,17 @@ async def analyze_youtube(
         message="YouTube URL accepted. Analysis started."
     )
 
-@router.get("/{job_id}")
+@router.get("/{job_id}", response_model=JobStatusResponse)
 async def get_analysis_result(job_id: str):
-    return {
-        "job_id": job_id,
-        "message": "Analysis endpoint scaffolded. Job orchestration will be implemented in a later branch."
-    }
+    job = job_store.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    return JobStatusResponse(
+        job_id=job.job_id,
+        status=job.status,
+        progress=job.progress,
+        message=job.message,
+        result=job.result,
+        error=job.error
+    )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -26,3 +26,6 @@ __all__ = [
     "RoiTimeSeries",
     "AnalysisResult",
 ]
+
+# Rebuild models to resolve forward references
+JobStatusResponse.model_rebuild()


### PR DESCRIPTION
## Summary

Implements the job status and analysis result retrieval endpoint for NeuroSafe. The frontend can now poll a submitted job ID and receive current progress, failure details, or the completed analysis result.

Closes #7 

## Changes

- Implemented `GET /api/analyze/{job_id}`
- Retrieves job state from the in-memory `job_store`
- Returns current job status, progress, message, result, and error fields
- Returns the full `AnalysisResult` only when the job is completed
- Returns clean `404 Not Found` responses for missing job IDs
- Handles failed jobs by returning the stored error message
- Updated schema exports to rebuild `JobStatusResponse` and resolve circular Pydantic references
- Updated README with polling verification instructions

## Validation

Tested full polling flow:

```powershell
$resp = Invoke-RestMethod -Uri http://localhost:8000/api/analyze/youtube -Method Post -ContentType "application/json" -Body '{"url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ"}'
Invoke-RestMethod -Uri "http://localhost:8000/api/analyze/$($resp.job_id)"