### PR TITLE
Add Hugging Face model adapter stub

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -87,6 +87,10 @@ uvicorn app.main:app --reload
   ```bash
   python -c "import asyncio; from app.adapters import demo_model_adapter; output=asyncio.run(demo_model_adapter.analyze_video('demo.mp4')); print(output.model_name, output.model_provider, output.duration_seconds); print(len(output.timestamps), len(output.roi_activations['V1'])); print(max(output.roi_activations['V1']), max(output.roi_activations['MT+']))"
   ```
+- **Hugging Face Adapter Stub Test:**
+  ```bash
+  python -c "from app.adapters import huggingface_model_adapter; print(huggingface_model_adapter.provider_name, huggingface_model_adapter.model_name)"
+  ```
 
 ## Note
 This is an initial scaffold. Model integration, job orchestration, Gemini integration, yt-dlp, and danger scoring will be added in later branches.

--- a/backend/app/adapters/__init__.py
+++ b/backend/app/adapters/__init__.py
@@ -1,4 +1,5 @@
 from app.adapters.base import BaseModelAdapter, RawModelOutput
 from app.adapters.demo_adapter import demo_model_adapter
+from app.adapters.huggingface_adapter import huggingface_model_adapter
 
-__all__ = ["BaseModelAdapter", "RawModelOutput", "demo_model_adapter"]
+__all__ = ["BaseModelAdapter", "RawModelOutput", "demo_model_adapter", "huggingface_model_adapter"]

--- a/backend/app/adapters/huggingface_adapter.py
+++ b/backend/app/adapters/huggingface_adapter.py
@@ -1,0 +1,82 @@
+import logging
+from typing import Optional, Dict, Any
+from app.adapters.base import BaseModelAdapter, RawModelOutput
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+class HuggingFaceModelAdapter(BaseModelAdapter):
+    """
+    Adapter for Hugging Face Inference Endpoints.
+    This is currently a stub for Developer 1 to plug into.
+    
+    Expected Future Response Shape:
+    {
+        "duration_seconds": 30.0,
+        "timestamps": [0.0, 1.0, 2.0, ...],
+        "roi_activations": {
+            "V1": [0.1, 0.2, 2.8, ...],
+            "V2": [0.1, 0.2, 2.1, ...],
+            "V3": [0.1, 0.2, 1.7, ...],
+            "V4": [0.1, 0.2, 1.2, ...],
+            "MT+": [0.1, 0.3, 2.6, ...]
+        },
+        "model_name": "tribe-v2-hf"
+    }
+    """
+
+    @property
+    def provider_name(self) -> str:
+        return "huggingface"
+
+    @property
+    def model_name(self) -> str:
+        # Use the URL as a proxy for the model name if not explicitly set
+        if settings.HF_API_URL:
+            return settings.HF_API_URL.split("/")[-1] or "huggingface-model"
+        return "huggingface-model"
+
+    async def analyze_video(self, video_path: str, job_id: Optional[str] = None) -> RawModelOutput:
+        """
+        Stub for video analysis via Hugging Face.
+        This will be implemented once Dev 1 provides the final model API contract.
+        """
+        # 1. Check Configuration
+        if not settings.HF_API_URL or not settings.HF_API_TOKEN:
+            logger.error("Hugging Face adapter called but HF_API_URL or HF_API_TOKEN is missing.")
+            raise RuntimeError(
+                "Hugging Face adapter is not configured. "
+                "Please set HF_API_URL and HF_API_TOKEN in your .env file."
+            )
+
+        # 2. TODO: Implement HTTP call to Hugging Face Inference Endpoint
+        # Example using httpx:
+        # async with httpx.AsyncClient() as client:
+        #     response = await client.post(...)
+        #     return self._parse_hf_response(response.json())
+
+        logger.warning(f"analyze_video called for {video_path} but Hugging Face adapter is still a stub.")
+        raise NotImplementedError(
+            "Hugging Face model inference is not yet implemented. "
+            "Developer 1 needs to provide the final API response contract."
+        )
+
+    def _parse_hf_response(self, response_json: Dict[str, Any]) -> RawModelOutput:
+        """
+        TODO: Implement parsing logic once the model output format is stable.
+        
+        Developer 1 Note:
+        The model must return timestamp-aligned ROI activations for:
+        V1, V2, V3, V4, and MT+.
+        """
+        # Example parsing:
+        # return RawModelOutput(
+        #     duration_seconds=response_json["duration_seconds"],
+        #     timestamps=response_json["timestamps"],
+        #     roi_activations=response_json["roi_activations"],
+        #     model_name=self.model_name,
+        #     model_provider=self.provider_name
+        # )
+        raise NotImplementedError("Hugging Face response parsing is not yet implemented.")
+
+huggingface_model_adapter = HuggingFaceModelAdapter()


### PR DESCRIPTION
## Summary

Adds a Hugging Face model adapter stub for NeuroSafe so Dev 1 has a clear future integration point for the real model endpoint.

Closes #10

## Changes

- Added backend/app/adapters/huggingface_adapter.py
  - HuggingFaceModelAdapter
  - huggingface_model_adapter singleton

- Updated backend/app/adapters/__init__.py
  - Exports huggingface_model_adapter

- Updated README with Hugging Face adapter verification command

## Adapter Behavior

The HuggingFaceModelAdapter reads configuration from the existing application settings:

- HF_API_URL
- HF_API_TOKEN

If the adapter is called without the required configuration, it raises a clear RuntimeError explaining that the Hugging Face adapter is not configured.

If the adapter is configured and called, it raises a NotImplementedError because the final HTTP logic and response parsing are waiting on Dev 1's final model API contract.

## Expected Future Model Contract

The future Hugging Face endpoint is expected to return timestamp-aligned ROI activation data in a structure like:

{
  "duration_seconds": 30.0,
  "timestamps": [0.0, 1.0, 2.0],
  "roi_activations": {
    "V1": [0.1, 0.2, 2.8],
    "V2": [0.1, 0.2, 2.1],
    "V3": [0.1, 0.2, 1.7],
    "V4": [0.1, 0.2, 1.2],
    "MT+": [0.1, 0.3, 2.6]
  },
  "model_name": "..."
}

This keeps the model output compatible with the backend danger scoring, brain visualization, and frontend synchronization pipeline.

## Validation

Tested adapter properties from backend/:

python -c "from app.adapters import huggingface_model_adapter; print(huggingface_model_adapter.provider_name, huggingface_model_adapter.model_name)"

Confirmed output:

huggingface huggingface-model

Tested expected missing-config failure:

python -c "import asyncio; from app.adapters import huggingface_model_adapter; asyncio.run(huggingface_model_adapter.analyze_video('demo.mp4'))"

Confirmed it raises a clear RuntimeError because the Hugging Face adapter is not configured.

Also confirmed the app still imports successfully and demo mode remains unaffected.

## Notes

This branch only adds the Hugging Face adapter stub. It does not implement real Hugging Face HTTP calls, local TRIBE v2 inference, route wiring, danger scoring, Gemini, YouTube downloading, or real brain rendering.