### PR TITLE
Build danger scoring service

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,31 @@
+# NeuroSafe backend environment configuration
+# Copy this file to .env for local development.
+# Never commit real secrets in .env.
+
+# Application environment: development, staging, or production.
 APP_ENV=development
+
+# Model provider used by the backend.
+# demo = use deterministic fake activation data for hackathon/demo mode.
+# huggingface = use Dev 1's future Hugging Face model endpoint.
 MODEL_PROVIDER=demo
+
+# Hugging Face model endpoint URL.
+# Required only when MODEL_PROVIDER=huggingface.
 HF_API_URL=
+
+# Hugging Face API token.
+# Required only when MODEL_PROVIDER=huggingface.
+# Do not commit real tokens.
 HF_API_TOKEN=
+
+# Gemini API key for report generation.
+# Optional for now. The backend should fall back to local demo reports if missing.
 GEMINI_API_KEY=
+
+# Directory where uploaded videos are saved locally.
 UPLOAD_DIR=./uploads
+
+# Comma-separated frontend origins allowed by CORS.
+# Keep localhost ports for Vite/React development.
 ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174,http://localhost:3000

--- a/backend/README.md
+++ b/backend/README.md
@@ -91,6 +91,10 @@ uvicorn app.main:app --reload
   ```bash
   python -c "from app.adapters import huggingface_model_adapter; print(huggingface_model_adapter.provider_name, huggingface_model_adapter.model_name)"
   ```
+- **Danger Scoring Service Test:**
+  ```bash
+  python -c "import asyncio; from app.adapters import demo_model_adapter; from app.services.danger_scoring import danger_scoring_service; output=asyncio.run(demo_model_adapter.analyze_video('demo.mp4')); score, summary, segments=danger_scoring_service.score_model_output(output); print(f'Score: {score}', f'Severity: {summary.severity}', f'Segments: {summary.segments_detected}'); print(f'First Segment: {segments[0].roi} at {segments[0].start_time}s, Peak: {segments[0].activation_level}')"
+  ```
 
 ## Note
 This is an initial scaffold. Model integration, job orchestration, Gemini integration, yt-dlp, and danger scoring will be added in later branches.

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,4 +1,5 @@
 from app.services.job_store import job_store, JobNotFoundError
 from app.services.orchestrator import analysis_orchestrator
+from app.services.danger_scoring import danger_scoring_service
 
-__all__ = ["job_store", "JobNotFoundError", "analysis_orchestrator"]
+__all__ = ["job_store", "JobNotFoundError", "analysis_orchestrator", "danger_scoring_service"]

--- a/backend/app/services/danger_scoring.py
+++ b/backend/app/services/danger_scoring.py
@@ -1,0 +1,107 @@
+from typing import List, Tuple, Dict
+from app.adapters.base import RawModelOutput
+from app.schemas.analysis import DangerSegment, AnalysisSummary
+
+class DangerScoringService:
+    """
+    Converts raw ROI activation data into seizure-risk segments and an overall score.
+    Based on threshold detection and segment grouping.
+    """
+    
+    def __init__(self, danger_threshold: float = 2.0):
+        self.danger_threshold = danger_threshold
+
+    def score_model_output(self, output: RawModelOutput) -> Tuple[int, AnalysisSummary, List[DangerSegment]]:
+        if not output.timestamps:
+            return 0, AnalysisSummary(severity="low", segments_detected=0, total_danger_duration_seconds=0), []
+
+        # Validate lengths
+        for roi, activations in output.roi_activations.items():
+            if len(activations) != len(output.timestamps):
+                raise ValueError(f"ROI {roi} activation length ({len(activations)}) does not match timestamp length ({len(output.timestamps)})")
+
+        segments = self._detect_segments(output)
+        
+        # Calculate overall metrics
+        total_segments = len(segments)
+        total_duration = sum(s.end_time - s.start_time for s in segments)
+        
+        max_activation = 0.0
+        if output.roi_activations:
+            max_activation = max(max(vals) for vals in output.roi_activations.values())
+
+        # Formula: score = min(100, int((max_activation / 3.2) * 70 + min(total_segments, 5) * 5 + min(total_duration, 10) * 1.5))
+        score = min(100, int((max_activation / 3.2) * 70 + min(total_segments, 5) * 5 + min(total_duration, 10) * 1.5))
+
+        # Severity
+        if score < 30:
+            severity = "low"
+        elif score < 70:
+            severity = "medium"
+        elif score < 90:
+            severity = "high"
+        else:
+            severity = "critical"
+
+        summary = AnalysisSummary(
+            severity=severity,
+            segments_detected=total_segments,
+            total_danger_duration_seconds=round(total_duration, 2)
+        )
+
+        return score, summary, segments
+
+    def _detect_segments(self, output: RawModelOutput) -> List[DangerSegment]:
+        all_segments = []
+        
+        for roi_name, activations in output.roi_activations.items():
+            in_segment = False
+            segment_start_idx = -1
+            
+            for i, (t, val) in enumerate(zip(output.timestamps, activations)):
+                if val >= self.danger_threshold:
+                    if not in_segment:
+                        in_segment = True
+                        segment_start_idx = i
+                else:
+                    if in_segment:
+                        # Close segment
+                        all_segments.append(self._create_segment(output, roi_name, segment_start_idx, i - 1))
+                        in_segment = False
+            
+            # Handle segment at the very end
+            if in_segment:
+                all_segments.append(self._create_segment(output, roi_name, segment_start_idx, len(output.timestamps) - 1))
+                
+        return all_segments
+
+    def _create_segment(self, output: RawModelOutput, roi: str, start_idx: int, end_idx: int) -> DangerSegment:
+        activations = output.roi_activations[roi][start_idx:end_idx + 1]
+        timestamps = output.timestamps[start_idx:end_idx + 1]
+        
+        peak_val = max(activations)
+        peak_idx = activations.index(peak_val)
+        peak_time = timestamps[peak_idx]
+        
+        # Severity inside segment
+        if peak_val >= 2.8:
+            severity = "critical"
+        elif peak_val >= 2.0:
+            severity = "high"
+        elif peak_val >= 1.5:
+            severity = "medium"
+        else:
+            severity = "low"
+
+        return DangerSegment(
+            start_time=output.timestamps[start_idx],
+            end_time=output.timestamps[end_idx],
+            peak_time=peak_time,
+            roi=roi,
+            activation_level=round(peak_val, 3),
+            threshold=self.danger_threshold,
+            severity=severity,
+            reason="Activation exceeded the visual cortex danger threshold."
+        )
+
+danger_scoring_service = DangerScoringService()


### PR DESCRIPTION
## Summary

Adds the danger scoring service for NeuroSafe. This service converts timestamp-aligned ROI activation data from model adapters into seizure-risk danger segments, an overall danger score, and an analysis summary.

Closes #11

## Changes

- Added backend/app/services/danger_scoring.py
  - DangerScoringService
  - danger_scoring_service singleton

- Updated backend/app/services/__init__.py
  - Exports danger_scoring_service

- Updated backend/.env.example
  - Added descriptive comments for all environment variables
  - Explained demo vs huggingface model providers
  - Clarified which values are optional and which are future integration points

- Updated backend/README.md
  - Added danger scoring documentation
  - Added danger scoring verification command

## Danger Scoring Behavior

The service uses threshold-based detection to convert RawModelOutput ROI activations into DangerSegment objects.

Default threshold:

- 2.0 activation level

Severity mapping:

- low: score < 30
- medium: score < 70
- high: score >= 70
- critical: score >= 90

Each danger segment includes:

- start_time
- end_time
- peak_time
- roi
- activation_level
- threshold
- severity
- reason

## Scoring Formula

The overall danger score is calculated from:

- maximum activation level
- number of danger segments
- total danger duration

This is intentionally simple, deterministic, and hackathon-friendly. It is not claiming to be a clinical diagnostic model.

## Dev 3 Integration Note

This service is an important bridge between Dev 1's future model output and Dev 2's frontend. It turns raw ROI activations into structured danger segments that can be synchronized with the video player, brain visualization, and timeline UI.

## Environment Documentation

The .env.example file now includes clear comments explaining:

- APP_ENV
- MODEL_PROVIDER
- HF_API_URL
- HF_API_TOKEN
- GEMINI_API_KEY
- UPLOAD_DIR
- ALLOWED_ORIGINS

This should make setup easier for Dev 1, Dev 2, and future contributors.

## Validation

Tested locally from backend/ using the DemoModelAdapter:

python -c "import asyncio; from app.adapters import demo_model_adapter; from app.services.danger_scoring import danger_scoring_service; output=asyncio.run(demo_model_adapter.analyze_video('demo.mp4')); score, summary, segments=danger_scoring_service.score_model_output(output); print(f'Score: {score}', f'Severity: {summary.severity}', f'Segments: {summary.segments_detected}'); print(f'First Segment: {segments[0].roi} at {segments[0].start_time}s, Peak: {segments[0].activation_level}')"

Confirmed output:

Score: 100 Severity: critical Segments: 5
First Segment: V1 at 15.0s, Peak: 2.934

Also confirmed the app still imports successfully.

## Notes

This branch only adds the danger scoring service and environment documentation cleanup. It does not wire danger scoring into the orchestrator yet and does not implement real model inference, Gemini API calls, YouTube downloading, or real brain rendering.