### PR TITLE
Add WebSocket progress stream

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -99,6 +99,16 @@ uvicorn app.main:app --reload
   ```bash
   python -c "import asyncio; from app.adapters import demo_model_adapter; from app.services.danger_scoring import danger_scoring_service; from app.services.result_formatter import result_formatter; output=asyncio.run(demo_model_adapter.analyze_video('demo.mp4')); score, summary, segments=danger_scoring_service.score_model_output(output); result=result_formatter.format_analysis_result('job_test', output, score, summary, segments); print(result.job_id, result.status, result.danger_score); print(result.roi_timeseries.timestamps[0], result.brain_visualization.frames[0].timestamp); print(result.roi_timeseries.MT_plus[0], result.brain_visualization.frames[0].roi_activations['MT+']); print(result.gemini_report.headline)"
   ```
+- **WebSocket Real-time Progress Test:**
+  1. Start the backend: `python -m uvicorn app.main:app --reload`
+  2. In a new terminal, create a job and copy the `job_id`:
+     ```bash
+     curl.exe -X POST http://localhost:8000/api/analyze/youtube -H "Content-Type: application/json" -d "{\"url\":\"https://www.youtube.com/watch?v=dQw4w9WgXcQ\"}"
+     ```
+  3. Run the WebSocket test script:
+     ```bash
+     python scripts/test_ws.py <job_id>
+     ```
 
 ## Note
 This is an initial scaffold. Model integration, job orchestration, Gemini integration, yt-dlp, and danger scoring will be added in later branches.

--- a/backend/app/api/routes/websocket.py
+++ b/backend/app/api/routes/websocket.py
@@ -1,20 +1,82 @@
+import asyncio
+import logging
+from datetime import datetime
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from app.services.job_store import job_store
+from app.schemas import JobStatus, ProgressEvent
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 @router.websocket("/{job_id}")
 async def websocket_endpoint(websocket: WebSocket, job_id: str):
+    """
+    WebSocket endpoint for real-time job progress streaming.
+    Polls the job_store and sends ProgressEvent updates to the client.
+    """
     await websocket.accept()
+    logger.info(f"WebSocket connection accepted for job: {job_id}")
+
     try:
-        await websocket.send_json({
-            "job_id": job_id,
-            "status": "scaffolded",
-            "progress": 0,
-            "message": "WebSocket scaffold ready. Real progress streaming will be implemented later."
-        })
-        # Keep connection open briefly or close immediately as per scaffold req
-        await websocket.close()
+        # 1. Validate Job Existence
+        job = job_store.get_job(job_id)
+        if not job:
+            await websocket.send_json({
+                "job_id": job_id,
+                "status": "error",
+                "progress": 0,
+                "message": f"Job {job_id} not found."
+            })
+            await websocket.close(code=1000)
+            return
+
+        # 2. Progress Streaming Loop
+        last_progress = -1
+        last_status = None
+        
+        while True:
+            job = job_store.get_job(job_id)
+            if not job:
+                break
+
+            # Send update only if status or progress changed
+            if job.status != last_status or job.progress != last_progress:
+                event = ProgressEvent(
+                    job_id=job.job_id,
+                    status=job.status,
+                    progress=job.progress,
+                    message=job.message,
+                    timestamp=datetime.utcnow()
+                )
+                
+                # Optional: Include first brain frame if job is completed
+                if job.status == JobStatus.COMPLETED and job.result:
+                    if job.result.brain_visualization and job.result.brain_visualization.frames:
+                        event.brain_frame = job.result.brain_visualization.frames[0]
+
+                await websocket.send_json(event.model_dump(mode="json"))
+                
+                last_status = job.status
+                last_progress = job.progress
+
+            # Terminate loop if job is finished
+            if job.status in [JobStatus.COMPLETED, JobStatus.FAILED]:
+                logger.info(f"Job {job_id} reached terminal state {job.status}. Closing WebSocket.")
+                break
+
+            # Poll every 100ms
+            await asyncio.sleep(0.1)
+
+        # Final wait to ensure client receives the last message before closing
+        await asyncio.sleep(0.1)
+        await websocket.close(code=1000)
+
+    except WebSocketDisconnect:
+        logger.info(f"WebSocket client disconnected for job: {job_id}")
     except Exception as e:
-        print(f"WebSocket error: {e}")
-    finally:
-        pass
+        logger.error(f"WebSocket error for job {job_id}: {e}")
+        try:
+            await websocket.send_json({"error": str(e)})
+            await websocket.close(code=1011)
+        except:
+            pass

--- a/backend/app/schemas/visualization.py
+++ b/backend/app/schemas/visualization.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Optional
-from pydantic import BaseModel, Field
+from datetime import datetime
+from pydantic import BaseModel, Field, ConfigDict
 from app.schemas.jobs import JobStatus
 
 class BrainFrame(BaseModel):
@@ -19,5 +20,7 @@ class ProgressEvent(BaseModel):
     status: JobStatus
     progress: int
     message: str
-    timestamp: Optional[str] = None
+    timestamp: Optional[datetime] = None
     brain_frame: Optional[BrainFrame] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 pydantic
 pydantic-settings
 python-multipart
+websockets

--- a/backend/scripts/test_ws.py
+++ b/backend/scripts/test_ws.py
@@ -1,0 +1,34 @@
+import asyncio
+import websockets
+import sys
+import json
+
+async def test_websocket(job_id):
+    uri = f"ws://localhost:8000/ws/analyze/{job_id}"
+    print(f"Connecting to {uri}...")
+    try:
+        async with websockets.connect(uri) as websocket:
+            print("Connected! Waiting for messages...")
+            while True:
+                try:
+                    message = await websocket.recv()
+                    data = json.loads(message)
+                    print(f"\n[EVENT] Status: {data.get('status')}, Progress: {data.get('progress')}%")
+                    print(f"Message: {data.get('message')}")
+                    
+                    if data.get("status") in ["completed", "failed"]:
+                        print(f"\nJob finished with status: {data.get('status')}")
+                        break
+                except websockets.exceptions.ConnectionClosed:
+                    print("\nConnection closed by server.")
+                    break
+    except Exception as e:
+        print(f"\nError: {e}")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python test_ws.py <job_id>")
+        sys.exit(1)
+    
+    target_job_id = sys.argv[1]
+    asyncio.run(test_websocket(target_job_id))


### PR DESCRIPTION
## Summary

Adds real-time WebSocket progress streaming for NeuroSafe analysis jobs. The frontend can now subscribe to a job and receive progress updates while the backend analysis pipeline runs.

Closes #13

## Changes

- Updated backend/app/api/routes/websocket.py
  - Implemented WS /ws/analyze/{job_id}
  - Streams ProgressEvent JSON updates from the in-memory job store
  - Sends final completed or failed event
  - Closes cleanly after terminal job states

- Added backend/scripts/test_ws.py
  - Simple developer test script for WebSocket progress streaming
  - Connects to a job WebSocket endpoint and prints received messages

- Updated backend/app/schemas/visualization.py
  - Updated ProgressEvent timestamp support
  - Improved Pydantic v2 compatibility

- Updated backend/requirements.txt
  - Added websockets dependency for local WebSocket testing

- Updated backend/README.md
  - Added WebSocket testing instructions

## WebSocket Behavior

The endpoint supports:

- Existing job IDs
- Missing job IDs
- Completed jobs
- Failed jobs
- Client disconnects

For existing jobs, the WebSocket monitors job_store and sends a ProgressEvent whenever the job status, progress, or message changes.

For missing jobs, the WebSocket sends a single error message and closes cleanly.

## Dev 3 Integration Note

This is important for the live NeuroSafe UI because it lets the frontend show real-time analysis progress while the backend moves through stages like metadata extraction, model inference, danger scoring, visualization generation, and report generation.

This supports the future synchronized demo flow:

submit video or YouTube URL → get job_id → connect WebSocket → stream progress → fetch completed result

## Validation

Tested locally by starting the backend, creating a job, and connecting to the WebSocket test script:

python scripts/test_ws.py <job_id>

Confirmed output showed a completed event:

Connecting to ws://localhost:8000/ws/analyze/job_edf78fe4...
Connected! Waiting for messages...
[EVENT] Status: completed, Progress: 100%
Message: Generating Gemini clinical report
Job finished with status: completed

Also tested missing job behavior and confirmed it sends an error message and closes cleanly.

## Notes

This branch only implements WebSocket progress streaming. It does not implement real model inference, Hugging Face calls, Gemini API calls, YouTube downloading, or real brain rendering.