### PR TITLE
Add reliable demo mode configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,31 +1,28 @@
-# NeuroSafe backend environment configuration
-# Copy this file to .env for local development.
-# Never commit real secrets in .env.
+# NeuroSafe Environment Configuration
+# Copy this file to .env and adjust as needed.
 
-# Application environment: development, staging, or production.
+# Application environment
 APP_ENV=development
 
-# Model provider used by the backend.
-# demo = use deterministic fake activation data for hackathon/demo mode.
-# huggingface = use Dev 1's future Hugging Face model endpoint.
+# Model Provider: "demo" (default) or "huggingface"
+# Demo mode uses deterministic fake activation data and requires no API keys.
 MODEL_PROVIDER=demo
 
-# Hugging Face model endpoint URL.
-# Required only when MODEL_PROVIDER=huggingface.
-HF_API_URL=
+# Hugging Face Settings (Required ONLY if MODEL_PROVIDER=huggingface)
+# HF_API_URL=https://api-inference.huggingface.co/models/your-model-here
+# HF_API_TOKEN=your_hf_token_here
 
-# Hugging Face API token.
-# Required only when MODEL_PROVIDER=huggingface.
-# Do not commit real tokens.
-HF_API_TOKEN=
-
-# Gemini API key for report generation.
-# Optional for now. The backend should fall back to local demo reports if missing.
+# Gemini API Key (Optional)
+# If provided, generates unique clinical reports. 
+# If missing, the backend falls back to a deterministic local report generator.
 GEMINI_API_KEY=
 
-# Directory where uploaded videos are saved locally.
+# Local Upload Directory
 UPLOAD_DIR=./uploads
 
-# Comma-separated frontend origins allowed by CORS.
-# Keep localhost ports for Vite/React development.
+# CORS Settings: Comma-separated list of allowed origins
 ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174,http://localhost:3000
+
+# FFmpeg/ffprobe Note:
+# ffprobe is used for video metadata extraction. If not installed, 
+# the backend will fall back to default metadata (30s, 30fps, 1080p).

--- a/backend/README.md
+++ b/backend/README.md
@@ -42,6 +42,34 @@ cp .env.example .env
 ```
 Default `MODEL_PROVIDER=demo` is used for development/testing without real model access.
 
+## Demo Mode
+By default, the backend runs in **Demo Mode** (`MODEL_PROVIDER=demo`). This mode is designed for hackathon presentations and local testing.
+
+### Key Features
+- **Zero Configuration**: Works out of the box without Hugging Face or Gemini API keys.
+- **Deterministic Data**: Uses realistic activation patterns for V1, V2, V3, V4, and MT+ regions.
+- **Full Pipeline Support**: Supports both direct MP4 uploads and YouTube URL submissions.
+- **Robust Fallbacks**: 
+    - If `ffprobe` is missing, defaults to 1080p/30fps metadata.
+    - If `yt-dlp` fails, falls back to demo analysis data.
+    - If `GEMINI_API_KEY` is missing, uses a local rule-based report generator.
+
+### Verification Commands
+Check configuration:
+```bash
+curl http://localhost:8000/api/analyze/demo/config
+```
+
+Run a YouTube test:
+```bash
+curl.exe -X POST http://localhost:8000/api/analyze/youtube -H "Content-Type: application/json" -d "{\"url\":\"https://www.youtube.com/watch?v=dQw4w9WgXcQ\"}"
+```
+
+Poll for results (replace `JOB_ID`):
+```bash
+curl http://localhost:8000/api/analyze/JOB_ID
+```
+
 ## Running the Backend
 ```bash
 uvicorn app.main:app --reload

--- a/backend/app/api/routes/analysis.py
+++ b/backend/app/api/routes/analysis.py
@@ -142,3 +142,22 @@ async def get_analysis_result(job_id: str):
         result=job.result,
         error=job.error
     )
+
+@router.get("/demo/config")
+async def get_demo_config():
+    """
+    Returns the current demo mode configuration.
+    Useful for judges and teammates to verify the environment.
+    """
+    return {
+        "model_provider": settings.MODEL_PROVIDER,
+        "is_demo_mode": settings.is_demo_mode,
+        "external_services_required": False if settings.is_demo_mode else True,
+        "features": {
+            "file_upload": True,
+            "youtube_url": True,
+            "websocket_progress": True,
+            "deterministic_results": settings.is_demo_mode,
+            "gemini_reports": "active" if settings.GEMINI_API_KEY else "fallback_mode"
+        }
+    }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,16 +1,46 @@
+import logging
 from typing import List
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 
+# Setup basic logging to show mode on startup
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 class Settings(BaseSettings):
     APP_ENV: str = "development"
+    
+    # Mode Configuration: "demo" or "huggingface"
     MODEL_PROVIDER: str = "demo"
+    
+    # External API Keys (Optional in demo mode)
     HF_API_URL: str = ""
     HF_API_TOKEN: str = ""
     GEMINI_API_KEY: str = ""
+    
+    # Local Storage
     UPLOAD_DIR: str = "./uploads"
-    ALLOWED_ORIGINS: List[str] = ["http://localhost:5173", "http://localhost:5174", "http://localhost:3000"]
+    
+    # CORS Configuration
+    ALLOWED_ORIGINS: List[str] = [
+        "http://localhost:5173", 
+        "http://localhost:5174", 
+        "http://localhost:3000"
+    ]
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
+    @property
+    def is_demo_mode(self) -> bool:
+        return self.MODEL_PROVIDER.lower() == "demo"
+
+    @property
+    def is_huggingface_mode(self) -> bool:
+        return self.MODEL_PROVIDER.lower() == "huggingface"
+
 settings = Settings()
+
+# Log active provider on startup
+logger.info(f"NeuroSafe Backend initialized with MODEL_PROVIDER={settings.MODEL_PROVIDER}")
+if settings.is_demo_mode:
+    logger.info("Demo mode is ACTIVE. External API keys are not required.")


### PR DESCRIPTION
## Summary

Adds explicit reliable demo mode configuration for the NeuroSafe backend. Demo mode is now clearly documented, easy to verify, and requires no external services or API keys.

Closes #17

## Changes

- Updated backend/app/core/config.py
  - Added is_demo_mode helper
  - Added is_huggingface_mode helper
  - Added startup visibility for active model provider

- Updated backend/app/api/routes/analysis.py
  - Added GET /api/analyze/demo/config for demo configuration visibility

- Updated backend/.env.example
  - Added clearer demo-first instructions
  - Documented optional external services
  - Clarified Hugging Face and Gemini configuration

- Updated backend/README.md
  - Added comprehensive Demo Mode section
  - Added smoke-test commands
  - Documented upload, YouTube, WebSocket, and polling demo flows

## Demo Mode Behavior

The backend defaults to:

MODEL_PROVIDER=demo

In demo mode, the backend does not require:

- HF_API_URL
- HF_API_TOKEN
- GEMINI_API_KEY
- successful YouTube downloads
- real model inference

The backend continues to provide deterministic demo analysis results, including danger segments, ROI time series, brain visualization frames, and fallback report text.

## Demo Config Endpoint

Added:

GET /api/analyze/demo/config

Example response:

{
  "model_provider": "demo",
  "is_demo_mode": true,
  "external_services_required": false,
  "features": {
    "file_upload": true,
    "youtube_url": true,
    "websocket_progress": true,
    "deterministic_results": true,
    "gemini_reports": "fallback_mode"
  }
}

This endpoint is intended for development, teammate integration, and judge/demo verification. It does not expose secrets.

## Validation

Verified settings behavior:

python -c "from app.core.config import settings; print(settings.MODEL_PROVIDER); print(settings.is_demo_mode)"

Confirmed output:

demo
True

Verified app import:

python -c "from app.main import app; print(app.title)"

Verified demo config endpoint:

curl.exe http://localhost:8000/api/analyze/demo/config

Confirmed the full demo pipeline remains functional without external API keys:

- Upload or YouTube submission returns job_id
- Job status/result polling works
- WebSocket progress works
- Deterministic analysis results are returned
- Gemini report falls back locally when no API key is provided

## Notes

This branch improves demo reliability and developer experience. It does not implement real model inference, production deployment, real brain rendering, or required external service dependencies.