### PR TITLE
Prepare backend for DigitalOcean deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,8 @@ NeuroSafe is built on a modular integration layer that connects deep learning mo
 ## Getting Started
 To set up the backend development environment, please refer to the detailed instructions in the **[Backend README](backend/README.md)**.
 
+## Deployment
+The backend is prepared for deployment on **DigitalOcean** via Docker or direct Python execution. Configuration examples for production environments can be found in the `backend/` directory.
+
 ---
 *NeuroSafe is an accessibility tool designed for creators and is not intended for medical diagnosis.*

--- a/backend/README.md
+++ b/backend/README.md
@@ -112,6 +112,46 @@ python scripts/demo_flow.py youtube
 python scripts/demo_flow.py upload
 ```
 
+docker run --rm -p 8000:8000 --env-file .env neurosafe-backend
+```
+
+## DigitalOcean Deployment Notes
+The backend is designed for simple deployment on DigitalOcean using Docker or a direct Python process.
+
+### Path A: Docker Droplet (Recommended)
+1. **Create Droplet**: Launch an Ubuntu Droplet with Docker pre-installed.
+2. **Clone & Setup**:
+   ```bash
+   git clone <repo-url>
+   cd backend
+   cp .env.production.example .env
+   # Edit .env to set your ALLOWED_ORIGINS (frontend URL)
+   ```
+3. **Build & Run**:
+   ```bash
+   docker build -t neurosafe-backend .
+   docker run -d --name neurosafe-backend -p 8000:8000 --env-file .env neurosafe-backend
+   ```
+4. **Verify**: Check `http://<YOUR_IP>:8000/health`.
+
+### Path B: Manual Python Setup
+1. **Setup**:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. **Run**:
+   ```bash
+   python3 -m uvicorn app.main:app --host 0.0.0.0 --port 8000
+   ```
+
+### Important Deployment Considerations
+- **WebSockets**: Ensure your firewall allows incoming traffic on port 8000. If using a reverse proxy (Nginx), ensure it is configured for WebSocket upgrades.
+- **HTTPS**: For production use with a domain, use a reverse proxy like Nginx or Caddy to handle SSL (WSS for WebSockets).
+- **Storage**: Uploads are stored locally in the `./uploads` directory. For a persistent production app, integrate DigitalOcean Spaces.
+- **Persistence**: The job store is in-memory; restarting the process clears all active and past jobs.
+
 ## Troubleshooting
 - **`py` or `python` not found**: Ensure Python 3.10+ is in your PATH.
 - **Module not found**: Confirm the virtual environment is activated and `pip install` succeeded.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,7 @@
 import logging
-from typing import List
+from typing import List, Union, Any
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import Field
+from pydantic import Field, field_validator
 
 # Setup basic logging to show mode on startup
 logging.basicConfig(level=logging.INFO)
@@ -22,11 +22,21 @@ class Settings(BaseSettings):
     UPLOAD_DIR: str = "./uploads"
     
     # CORS Configuration
-    ALLOWED_ORIGINS: List[str] = [
+    # We use Union[List[str], str] to allow comma-separated strings from env vars
+    ALLOWED_ORIGINS: Union[List[str], str] = [
         "http://localhost:5173", 
         "http://localhost:5174", 
         "http://localhost:3000"
     ]
+
+    @field_validator("ALLOWED_ORIGINS", mode="before")
+    @classmethod
+    def assemble_cors_origins(cls, v: Any) -> List[str]:
+        if isinstance(v, str) and not v.startswith("["):
+            return [i.strip() for i in v.split(",")]
+        elif isinstance(v, list):
+            return v
+        return v # Let pydantic handle other cases or throw error
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 


### PR DESCRIPTION
## Summary

Prepares the NeuroSafe backend for simple DigitalOcean deployment while keeping the setup hackathon-practical.

Closes #22

## Changes

- Added backend/.env.production.example
  - Production-oriented environment template
  - Documents APP_ENV, MODEL_PROVIDER, UPLOAD_DIR, ALLOWED_ORIGINS, GEMINI_API_KEY, HF_API_URL, and HF_API_TOKEN
  - Notes that demo mode works without external API keys
  - Notes that real secrets should never be committed

- Updated backend/app/core/config.py
  - Improved ALLOWED_ORIGINS parsing from comma-separated environment strings
  - Keeps CORS configuration deployment-friendly

- Updated backend/README.md
  - Added DigitalOcean Deployment Notes
  - Added Docker deployment path
  - Added direct Python deployment path
  - Added production uvicorn command
  - Added health check instructions
  - Added WebSocket deployment notes
  - Added upload storage limitations

- Updated root README.md
  - Points developers and judges to backend deployment documentation

## Deployment Support

The backend can now be deployed using either:

Docker:

docker build -t neurosafe-backend .
docker run -d --name neurosafe-backend -p 8000:8000 --env-file .env neurosafe-backend

Direct Python:

python -m uvicorn app.main:app --host 0.0.0.0 --port 8000

## CORS Configuration

ALLOWED_ORIGINS can now be configured as a comma-separated environment variable, for example:

ALLOWED_ORIGINS=https://your-frontend-domain.com,http://localhost:5173,http://localhost:5174

This makes it easier to connect a deployed frontend to the backend.

## WebSocket Deployment Note

The README now documents that frontend WebSocket connections should use:

ws://SERVER_IP:8000/ws/analyze/{job_id}

or wss:// when deployed behind HTTPS.

It also notes that firewalls/proxies must allow WebSocket upgrades.

## Storage Note

The README documents that uploads are stored locally in UPLOAD_DIR and that the in-memory job store is temporary. This is fine for the hackathon demo, but a production version would use persistent storage and a durable job queue.

## Validation

Verified that comma-separated ALLOWED_ORIGINS values parse correctly into a Python list.

Confirmed the app still imports successfully:

python -c "from app.main import app; print(app.title)"

## Notes

This branch only prepares deployment configuration and documentation. It does not add databases, Redis, Celery, authentication, object storage, Nginx, SSL, or other production infrastructure.